### PR TITLE
Kernel optimizations

### DIFF
--- a/DoseCUDA/dose_kernels/CudaClasses.cu
+++ b/DoseCUDA/dose_kernels/CudaClasses.cu
@@ -211,10 +211,10 @@ __global__ void rayTraceKernel(CudaDose * dose, CudaBeam * beam, Texture3D Densi
 
 	PointXYZ vox_ray_xyz, tex_xyz;
 
-    float ray_length = 0.0;
-    float wet_sum = -0.05;
-    float density = 0.0;
-	const float step_length = 1.0;
+    float ray_length = 0.0f;
+    float wet_sum = -0.05f;
+    float density = 0.0f;
+	const float step_length = 1.0f;
 
     while(true){
 
@@ -228,7 +228,7 @@ __global__ void rayTraceKernel(CudaDose * dose, CudaBeam * beam, Texture3D Densi
 		}
 		density = DensityTexture.sample(tex_xyz);
 
-		wet_sum = fmaf(fmaxf(density, 0.0), step_length / 10.0, wet_sum);
+		wet_sum = fmaf(fmaxf(density, 0.0f), step_length / 10.0f, wet_sum);
 
 		ray_length += step_length;
 

--- a/DoseCUDA/dose_kernels/CudaClasses.cuh
+++ b/DoseCUDA/dose_kernels/CudaClasses.cuh
@@ -132,4 +132,14 @@ __host__ __device__ static inline int lowerBound(const T data[], int len, T key)
     return l;
 }
 
+__device__ static inline float sqr(float x)
+{
+    return x * x;
+}
+
+__device__ static inline float clamp(float x, float lo, float hi)
+{
+    return fminf(fmaxf(x, lo), hi);
+}
+
 #endif

--- a/DoseCUDA/dose_kernels/IMPTClasses.cu
+++ b/DoseCUDA/dose_kernels/IMPTClasses.cu
@@ -94,7 +94,7 @@ __device__ void IMPTBeam::interpolateProtonLUT(float wet, float * idd, float * s
 __device__ float IMPTBeam::sigmaAir(float wet, float distance_to_source, unsigned layer_id) {
 
 	Layer &layer = this->layers[layer_id];
-	float d = distance_to_source - wet + (0.7 * layer.r80);
+	float d = distance_to_source - wet + (0.7f * layer.r80);
 	const float *coef = &this->divergence_params[this->dvp_len * layer.energy_id + 2];
 
 	return fmaf(fmaf(coef[0], d, coef[1]), d, coef[2]);
@@ -105,24 +105,24 @@ __device__ void IMPTBeam::nuclearHalo(float wet, float * halo_sigma, float * hal
 
 	Layer &layer = this->layers[layer_id];
 
-	wet = clamp(wet, 0.1, layer.r80 - 0.1);
+	wet = clamp(wet, 0.1f, layer.r80 - 0.1f);
 
-	float halo_sigma_ = 2.85 + (0.0014 * layer.r80 * logf(wet + 3.0)) +
-	(0.06 * wet) - (7.4e-5 * sqr(wet)) -
-	((0.22 * layer.r80) / sqr(wet - layer.r80 - 5.0));
+	float halo_sigma_ = 2.85f + (0.0014f * layer.r80 * logf(wet + 3.0f)) +
+	(0.06f * wet) - (7.4e-5f * sqr(wet)) -
+	((0.22f * layer.r80) / sqr(wet - layer.r80 - 5.0f));
 
-	float halo_weight_ = 0.052 * logf(1.13 + (wet / (11.2 - (0.023 * layer.r80)))) +
-	(0.35 * ((0.0017 * sqr(layer.r80)) - layer.r80) / (sqr(layer.r80 + 3.0) - sqr(wet))) -
-	(1.61e-9 * wet * sqr(layer.r80 + 3.0));
+	float halo_weight_ = 0.052f * logf(1.13f + (wet / (11.2f - (0.023f * layer.r80)))) +
+	(0.35f * ((0.0017f * sqr(layer.r80)) - layer.r80) / (sqr(layer.r80 + 3.0f) - sqr(wet))) -
+	(1.61e-9f * wet * sqr(layer.r80 + 3.0f));
 
-	*halo_sigma = fmaxf(halo_sigma_, 0.0);
-	*halo_weight = clamp(halo_weight_, 0.0, 0.9);
+	*halo_sigma = fmaxf(halo_sigma_, 0.0f);
+	*halo_weight = clamp(halo_weight_, 0.0f, 0.9f);
 
 }
 
 __device__ float IMPTBeam::caxDistance(const Spot &spot, const PointXYZ &vox)
 {
-	PointXYZ tangent = { spot.x / model.vsadx, spot.y / model.vsady, -1.0 };
+	PointXYZ tangent = { spot.x / model.vsadx, spot.y / model.vsady, -1.0f };
 	PointXYZ ray = { vox.x - spot.x, vox.y - spot.y, vox.z };
 
 	const auto tansqr = xyz_dotproduct(tangent, tangent);
@@ -155,7 +155,7 @@ __global__ void smoothRayKernel(IMPTDose * dose, CudaBeam * beam, float * Smooth
 	PointXYZ uvec;
 	beam->unitVectorToSource(&vox_xyz, &uvec);
 
-	float step_length = 1.0;
+	float step_length = 1.0f;
 
 	PointXYZ vox_head_xyz;
 	PointXYZ vox_head_xyz_conv;
@@ -173,10 +173,10 @@ __global__ void smoothRayKernel(IMPTDose * dose, CudaBeam * beam, float * Smooth
 	for (int i=0; i<6; i++){
 		float sinx, cosx;
 
-		dr = 1.0;
-		sincosf((float)i * CUDART_PI_F / 3.0, &sinx, &cosx);
+		dr = 1.0f;
+		sincosf((float)i * CUDART_PI_F / 3.0f, &sinx, &cosx);
 
-		while ((dr < (center_wet * 10.0)) & (dr < 10.0)){
+		while ((dr < (center_wet * 10.0f)) && (dr < 10.0f)){
 
 			vox_head_xyz_conv.x = vox_head_xyz.x + (dr * cosx);
 			vox_head_xyz_conv.y = vox_head_xyz.y + (dr * sinx);
@@ -219,9 +219,9 @@ __global__ void pencilBeamKernel(IMPTDose * dose, IMPTBeam * beam){
 
 	unsigned vox_index = dose->pointIJKtoIndex(&vox_ijk);
 
-	float wet = dose->WETArray[vox_index] * 10.0;
+	float wet = dose->WETArray[vox_index] * 10.0f;
 
-	if (wet > (1.1 * beam->layers[layer_id].r80)){
+	if (wet > (1.1f * beam->layers[layer_id].r80)){
 		return;
 	}
 
@@ -240,10 +240,10 @@ __global__ void pencilBeamKernel(IMPTDose * dose, IMPTBeam * beam){
 
 	Layer &layer = beam->layers[layer_id];
 
-	float primary_dose_factor = (1.0 - halo_weight) * idd / (2.0 * CUDART_PI_F * sqr(sigma_total));
-	float halo_dose_factor = halo_weight * idd / (2.0 * CUDART_PI_F * sqr(sigma_halo_total));
+	float primary_dose_factor = (1.0f - halo_weight) * idd / (2.0f * CUDART_PI_F * sqr(sigma_total));
+	float halo_dose_factor = halo_weight * idd / (2.0f * CUDART_PI_F * sqr(sigma_halo_total));
 
-	float total_dose = 0.0, primary_dose, halo_dose;
+	float total_dose = 0.0f, primary_dose, halo_dose;
 
 	beam->pointXYZImageToHead(&vox_xyz, &vox_head_xyz);
 

--- a/DoseCUDA/dose_kernels/IMPTClasses.cu
+++ b/DoseCUDA/dose_kernels/IMPTClasses.cu
@@ -66,7 +66,7 @@ __host__ void IMPTBeam::importLayers(){
 
 }
 
-__device__ void IMPTBeam::interpolateProtonLUT(float wet, float * idd, float * sigma, size_t layer_id){
+__device__ void IMPTBeam::interpolateProtonLUT(float wet, float * idd, float * sigma, unsigned layer_id){
 
 	const Layer &layer = this->layers[layer_id];
 	const float *depths, *sigmas, *idds;
@@ -91,7 +91,7 @@ __device__ void IMPTBeam::interpolateProtonLUT(float wet, float * idd, float * s
 
 }
 
-__device__ float IMPTBeam::sigmaAir(float wet, float distance_to_source, size_t layer_id) {
+__device__ float IMPTBeam::sigmaAir(float wet, float distance_to_source, unsigned layer_id) {
 
 	Layer &layer = this->layers[layer_id];
 	float d = distance_to_source - wet + (0.7 * layer.r80);
@@ -101,17 +101,7 @@ __device__ float IMPTBeam::sigmaAir(float wet, float distance_to_source, size_t 
 
 }
 
-__device__ float clamp(float x, float lo, float hi)
-{
-	return fmaxf(fminf(x, hi), lo);
-}
-
-__device__ float sqr(float x)
-{
-	return x * x;
-}
-
-__device__ void IMPTBeam::nuclearHalo(float wet, float * halo_sigma, float * halo_weight, size_t layer_id) {
+__device__ void IMPTBeam::nuclearHalo(float wet, float * halo_sigma, float * halo_weight, unsigned layer_id) {
 
 	Layer &layer = this->layers[layer_id];
 
@@ -217,7 +207,7 @@ __global__ void pencilBeamKernel(IMPTDose * dose, IMPTBeam * beam){
 	vox_ijk.k = threadIdx.x + (blockIdx.x * blockDim.x);
 	vox_ijk.j = threadIdx.y + (blockIdx.y * blockDim.y);
 	vox_ijk.i = (threadIdx.z + (blockIdx.z * blockDim.z)) / beam->n_layers;
-	size_t layer_id = (threadIdx.z + (blockIdx.z * blockDim.z)) % beam->n_layers;
+	unsigned layer_id = (threadIdx.z + (blockIdx.z * blockDim.z)) % beam->n_layers;
 
 	if (layer_id >= beam->n_layers){
 		return;
@@ -227,7 +217,7 @@ __global__ void pencilBeamKernel(IMPTDose * dose, IMPTBeam * beam){
 		return;
 	}
 
-	size_t vox_index = dose->pointIJKtoIndex(&vox_ijk);
+	unsigned vox_index = dose->pointIJKtoIndex(&vox_ijk);
 
 	float wet = dose->WETArray[vox_index] * 10.0;
 

--- a/DoseCUDA/dose_kernels/IMPTClasses.cuh
+++ b/DoseCUDA/dose_kernels/IMPTClasses.cuh
@@ -57,11 +57,11 @@ class IMPTBeam : public CudaBeam{
 
         __host__ void importLayers();
 
-        __device__ void interpolateProtonLUT(float wet, float * idd, float * sigma, size_t layer_id);
+        __device__ void interpolateProtonLUT(float wet, float * idd, float * sigma, unsigned layer_id);
 
-        __device__ float sigmaAir(float wet, float distance_to_source, size_t layer_id);
+        __device__ float sigmaAir(float wet, float distance_to_source, unsigned layer_id);
 
-        __device__ void nuclearHalo(const float wet, float * halo_sigma, float * halo_weight, size_t layer_id);
+        __device__ void nuclearHalo(const float wet, float * halo_sigma, float * halo_weight, unsigned layer_id);
 
         /** @brief Compute the @b squared distance of voxel coordinates to their
          *      nearest point on a pencil beam

--- a/DoseCUDA/dose_kernels/IMRTClasses.cuh
+++ b/DoseCUDA/dose_kernels/IMRTClasses.cuh
@@ -22,12 +22,12 @@ class IMRTBeam : public CudaBeam{
 
         struct Model {
 
-            size_t n_profile_points;
+            int n_profile_points;
             float * profile_radius;
             float * profile_intensities;
             float * profile_softening;
 
-            size_t n_spectral_energies;
+            int n_spectral_energies;
             float * spectrum_attenuation_coefficients;
             float * spectrum_primary_weights;
             float * spectrum_scatter_weights;

--- a/DoseCUDA/dose_kernels/PointClasses.cuh
+++ b/DoseCUDA/dose_kernels/PointClasses.cuh
@@ -5,9 +5,9 @@
 
 typedef struct {
 
-    size_t i;
-    size_t j;
-    size_t k;
+    unsigned i;
+    unsigned j;
+    unsigned k;
 
 } PointIJK;
 

--- a/DoseCUDA/dose_kernels/TextureClasses.cu
+++ b/DoseCUDA/dose_kernels/TextureClasses.cu
@@ -11,7 +11,7 @@ void Texture3D::makeArray(const PointIJK &size)
 }
 
 
-void Texture3D::makeTexture(cudaTextureFilterMode filterMode)
+void Texture3D::makeTexture(cudaTextureFilterMode filterMode, float border)
 {
     cudaResourceDesc rsdesc{ };
     cudaTextureDesc txdesc{ };
@@ -19,13 +19,13 @@ void Texture3D::makeTexture(cudaTextureFilterMode filterMode)
     rsdesc.resType = cudaResourceTypeArray;
     rsdesc.res.array.array = m_arr;
 
-    txdesc.addressMode[0]               = cudaAddressModeClamp;
-    txdesc.addressMode[1]               = cudaAddressModeClamp;
-    txdesc.addressMode[2]               = cudaAddressModeClamp;
+    txdesc.addressMode[0]               = cudaAddressModeBorder;
+    txdesc.addressMode[1]               = cudaAddressModeBorder;
+    txdesc.addressMode[2]               = cudaAddressModeBorder;
     txdesc.filterMode                   = filterMode;
     txdesc.readMode                     = cudaReadModeElementType;
     txdesc.sRGB                         = false;
-    txdesc.borderColor[0]               = 0.0f;
+    txdesc.borderColor[0]               = border;
     txdesc.borderColor[1]               = 0.0f;
     txdesc.borderColor[2]               = 0.0f;
     txdesc.borderColor[3]               = 0.0f;
@@ -41,7 +41,7 @@ void Texture3D::makeTexture(cudaTextureFilterMode filterMode)
 }
 
 
-Texture3D::Texture3D(const float data[], const PointIJK &size, cudaTextureFilterMode filterMode, cudaMemcpyKind direction):
+Texture3D::Texture3D(const float data[], const PointIJK &size, cudaTextureFilterMode filterMode, float border, cudaMemcpyKind direction):
     m_arr(NULL),
     m_tex(0),
     m_isCopy(false)
@@ -55,7 +55,7 @@ Texture3D::Texture3D(const float data[], const PointIJK &size, cudaTextureFilter
     params.kind     = direction;
     CUDA_CHECK(cudaMemcpy3D(&params));
 
-    this->makeTexture(filterMode);
+    this->makeTexture(filterMode, border);
 }
 
 

--- a/DoseCUDA/dose_kernels/TextureClasses.cuh
+++ b/DoseCUDA/dose_kernels/TextureClasses.cuh
@@ -13,9 +13,9 @@ class Texture3D {
     bool                m_isCopy;
 
     void makeArray(const PointIJK &size);
-    void makeTexture(cudaTextureFilterMode filterMode);
+    void makeTexture(cudaTextureFilterMode filterMode, float border);
 
-    Texture3D(const float data[], const PointIJK &size, cudaTextureFilterMode filterMode, cudaMemcpyKind direction);
+    Texture3D(const float data[], const PointIJK &size, cudaTextureFilterMode filterMode, float border, cudaMemcpyKind direction);
 
 public:
     Texture3D(const Texture3D &other):
@@ -40,9 +40,9 @@ public:
      *      Desired filtering mode for sampling from this texture
      *  @returns A new 3D texture to be used for sampling in device code
      */
-    static __host__ Texture3D fromHostData(const float h_data[], const PointIJK &size, cudaTextureFilterMode filterMode=cudaFilterModePoint) {
+    static __host__ Texture3D fromHostData(const float h_data[], const PointIJK &size, cudaTextureFilterMode filterMode=cudaFilterModePoint, float border=0.0f) {
 
-        return Texture3D(h_data, size, filterMode, cudaMemcpyHostToDevice);
+        return Texture3D(h_data, size, filterMode, border, cudaMemcpyHostToDevice);
     }
 
     /** @brief Create a texture from 3D device data
@@ -54,9 +54,9 @@ public:
      *      Desired filtering mode for sampling from this texture
      *  @returns A new 3D texture to be used for sampling in device code
      */
-    static __host__ Texture3D fromDeviceData(const float d_data[], const PointIJK &size, cudaTextureFilterMode filterMode=cudaFilterModePoint) {
+    static __host__ Texture3D fromDeviceData(const float d_data[], const PointIJK &size, cudaTextureFilterMode filterMode=cudaFilterModePoint, float border=0.0f) {
 
-        return Texture3D(d_data, size, filterMode, cudaMemcpyDeviceToDevice);
+        return Texture3D(d_data, size, filterMode, border, cudaMemcpyDeviceToDevice);
     }
 
     /** @brief Sample from this texture using real-valued pixel coordinates */


### PR DESCRIPTION
Speed up some CUDA kernels by increasing [occupancy](https://docs.nvidia.com/gameworks/content/developertools/desktop/analysis/report/cudaexperiments/kernellevel/achievedoccupancy.htm) and reducing warp divergence:

- Use 32-bit integer types instead of `size_t` wherever possible
- Add border addressing to textures
  - Out-of-bounds accesses now provide a fixed value specified per-texture
  - Eliminates conditional branching for bounds checking in `cccKernel`
- Cache trigonometric function results in `cccKernel` to reduce register pressure