### PR TITLE
CCC kernel tilting

### DIFF
--- a/DoseCUDA/dose_kernels/CudaClasses.cu
+++ b/DoseCUDA/dose_kernels/CudaClasses.cu
@@ -50,19 +50,6 @@ __host__ CudaBeam::CudaBeam(float * iso, float gantry_angle, float couch_angle, 
 
 }
 
-__device__ void CudaBeam::unitVectorToSource(const PointXYZ * point_xyz, PointXYZ * uvec) {
-
-	float dx = this->src.x - point_xyz->x;
-	float dy = this->src.y - point_xyz->y;
-	float dz = this->src.z - point_xyz->z;
-
-	float r = rnorm3df(dx, dy, dz);
-
-	uvec->x = dx * r;
-	uvec->y = dy * r;
-	uvec->z = dz * r;
-}
-
 __device__ float CudaBeam::distanceToSource(const PointXYZ * point_xyz){
 	
 	float dx = this->src.x - point_xyz->x;

--- a/DoseCUDA/dose_kernels/CudaClasses.cuh
+++ b/DoseCUDA/dose_kernels/CudaClasses.cuh
@@ -38,7 +38,18 @@ class CudaBeam{
         __host__ CudaBeam(CudaBeam * h_beam);
         __host__ CudaBeam(float * iso, float gantry_angle, float couch_angle, float src_dist);
 
-        __device__ void unitVectorToSource(const PointXYZ * point_xyz, PointXYZ * uvec);
+        __device__ void unitVectorToSource(const PointXYZ * point_xyz, PointXYZ * uvec) {
+
+            uvec->x = this->src.x - point_xyz->x;
+            uvec->y = this->src.y - point_xyz->y;
+            uvec->z = this->src.z - point_xyz->z;
+
+            const auto norm = rnorm3df(uvec->x, uvec->y, uvec->z);
+            uvec->x *= norm;
+            uvec->y *= norm;
+            uvec->z *= norm;
+
+        }
 
         __device__ float distanceToSource(const PointXYZ * point_xyz);
 

--- a/DoseCUDA/dose_kernels/IMRTClasses.cu
+++ b/DoseCUDA/dose_kernels/IMRTClasses.cu
@@ -268,9 +268,13 @@ __global__ void cccKernel(IMRTDose * dose, IMRTBeam * beam, Texture3D TERMATextu
 
 		for(int j = 0; j < 12; j++){
 
-			float xr = sinth * trig[j].cosx;
-			float yr = sinth * trig[j].sinx;
-			float zr = costh;
+			PointXYZ tangent_head_xyz;
+			tangent_head_xyz.x = sinth * trig[j].cosx;
+			tangent_head_xyz.y = sinth * trig[j].sinx;
+			tangent_head_xyz.z = costh;
+
+			PointXYZ tangent_img_xyz;
+			beam->pointXYZHeadToImage(&tangent_head_xyz, &tangent_img_xyz);
 
 			float Rs = 0.0f, Rp = 0.0f, Ti = 0.0f;
 			float Di = AIR_DENSITY * sp;
@@ -278,13 +282,10 @@ __global__ void cccKernel(IMRTDose * dose, IMRTBeam * beam, Texture3D TERMATextu
 
 			while(ray_length >= 0.0f) {
 
-				PointXYZ ray_head_xyz;
-				ray_head_xyz.x = fmaf(xr, ray_length * 10.0f, vox_head_xyz.x);
-				ray_head_xyz.y = fmaf(yr, ray_length * 10.0f, vox_head_xyz.y);
-				ray_head_xyz.z = fmaf(zr, ray_length * 10.0f, vox_head_xyz.z);
-
 				PointXYZ ray_img_xyz;
-				beam->pointXYZHeadToImage(&ray_head_xyz, &ray_img_xyz);
+				ray_img_xyz.x = fmaf(tangent_img_xyz.x, ray_length * 10.0f, vox_img_xyz.x);
+				ray_img_xyz.y = fmaf(tangent_img_xyz.y, ray_length * 10.0f, vox_img_xyz.y);
+				ray_img_xyz.z = fmaf(tangent_img_xyz.z, ray_length * 10.0f, vox_img_xyz.z);
 
 				dose->pointXYZtoTextureXYZ(&ray_img_xyz, &tex_img_xyz, beam);
 				Ti = TERMATexture.sample(tex_img_xyz);

--- a/DoseCUDA/dose_kernels/IMRTClasses.cuh
+++ b/DoseCUDA/dose_kernels/IMRTClasses.cuh
@@ -71,6 +71,9 @@ class IMRTBeam : public CudaBeam{
 
 		__device__ void offAxisFactors(const PointXYZ * point_xyz, float * off_axis_factor, float * off_axis_softening);
 
+        /** Tilt an IMAGE-space tangent vector such that its z points toward the source */
+        __device__ void kernelTilt(const PointXYZ * vox_img_xyz, PointXYZ * vec_img);
+
 		/** Takes collimator angle into account */
 		__device__ void pointXYZImageToHead(const PointXYZ * point_img, PointXYZ * point_head);
 

--- a/DoseCUDA/dose_kernels/PointClasses.cuh
+++ b/DoseCUDA/dose_kernels/PointClasses.cuh
@@ -24,4 +24,14 @@ __host__ __device__ static inline float xyz_dotproduct(const PointXYZ &a, const 
     return a.x * b.x + a.y * b.y + a.z * b.z;
 }
 
+__host__ __device__ static inline PointXYZ xyz_crossproduct(const PointXYZ &a, const PointXYZ &b) {
+
+    PointXYZ res;
+
+    res.x = a.y * b.z - a.z * b.y;
+    res.y = a.z * b.x - a.x * b.z;
+    res.z = a.x * b.y - a.y * b.x;
+    return res;
+}
+
 #endif /* POINT_CLASSES_H */


### PR DESCRIPTION
Add kernel tilting to `cccKernel`

This implementation uses a slightly modified version of [Rodrigues' formula](https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula) to rotate the kernel's image-space tangent vector.

There is little to no performance hit, so kernel tilting is done unconditionally, without regard to the voxel's distance from CAX.